### PR TITLE
Update to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
     "name": "mozz.env",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "main": "dist/main.js",
     "description": "Your JavaScript Environment Enhancer",
     "license": "LGPL-3.0-only",
     "author": "Amélia Ribeiro <contato@ameliazz.xyz> (https://ameliazz.xyz/)",
     "keywords": [
-        "environment",
-        "enhancer"
+        "mozz",
+        "enhancer",
+        "env",
+        "environment"
     ],
     "repository": "https://github.com/Canary2000/mozz.js.git",
     "scripts": {

--- a/source/structures/Env.struct.ts
+++ b/source/structures/Env.struct.ts
@@ -12,7 +12,8 @@ if (!process.env['MOZZ_ENV']) {
 }
 
 type MozzProfileSettingsType = {
-    allowEnvSwitch: boolean
+    allowEnvSwitch?: boolean
+    allowUndefinedValues?: boolean
 }
 
 interface MozzProfileObjectType {
@@ -114,13 +115,43 @@ export default class Env {
             }
 
             for (const item in ParsedConfigFileData) {
-                this[item] = ParseEnvValue(
+                const value = ParseEnvValue(
                     ParsedConfigFileData[item as keyof object]
                 )
+
+                if (
+                    typeof value == 'undefined' &&
+                    !this.MOZZ_SETTINGS.allowUndefinedValues
+                ) {
+                    throw new Error(
+                        `${
+                            `"${item}"`.cyan
+                        } has been assigned an undefined value. Try enabling the ${
+                            '"allowUndefinedValues"'.green
+                        } option.`
+                    )
+                }
+
+                this[item] = value
             }
         } else {
             for (const item in MozzConfig) {
-                this[item] = ParseEnvValue(MozzConfig[item])
+                const value = ParseEnvValue(MozzConfig[item])
+
+                if (
+                    typeof value == 'undefined' &&
+                    !this.MOZZ_SETTINGS.allowUndefinedValues
+                ) {
+                    throw new Error(
+                        `${
+                            `"${item}"`.cyan
+                        } has been assigned an undefined value. Try enabling the ${
+                            '"allowUndefinedValues"'.green
+                        } option.`
+                    )
+                }
+                
+                this[item] = value
             }
         }
 

--- a/source/structures/Env.struct.ts
+++ b/source/structures/Env.struct.ts
@@ -4,6 +4,7 @@ import TOML from 'toml'
 import defaults from '../defaults'
 import DotEnv from 'dotenv'
 import ParseEnvValue from 'utils/Parse.util'
+
 DotEnv.config()
 
 if (!process.env['MOZZ_ENV']) {
@@ -119,7 +120,7 @@ export default class Env {
             }
         } else {
             for (const item in MozzConfig) {
-                this[item] = MozzConfig[item]
+                this[item] = ParseEnvValue(MozzConfig[item])
             }
         }
 

--- a/source/structures/Env.struct.ts
+++ b/source/structures/Env.struct.ts
@@ -3,6 +3,7 @@ import TOML from 'toml'
 
 import defaults from '../defaults'
 import DotEnv from 'dotenv'
+import ParseEnvValue from 'utils/Parse.util'
 DotEnv.config()
 
 if (!process.env['MOZZ_ENV']) {
@@ -96,27 +97,25 @@ export default class Env {
                 'utf-8'
             )
 
+            let ParsedConfigFileData: Object = {}
+
             switch (fileType.toLowerCase()) {
                 case 'json':
-                    const ConfigObjectJSONParsed = JSON.parse(fileContent)
-                    for (const item in ConfigObjectJSONParsed) {
-                        this[item] = ConfigObjectJSONParsed[item]
-                    }
-
+                    ParsedConfigFileData = JSON.parse(fileContent)
                     break
 
                 case 'toml':
-                    const ConfigObjectTOMLParsed = TOML.parse(fileContent)
-                    for (const item in ConfigObjectTOMLParsed) {
-                        this[item] = ConfigObjectTOMLParsed[item]
-                    }
-
+                    ParsedConfigFileData = TOML.parse(fileContent)
                     break
 
                 default:
-                    for (const item in MozzConfig) {
-                        this[item] = MozzConfig[item]
-                    }
+                    ParsedConfigFileData = MozzConfig
+            }
+
+            for (const item in ParsedConfigFileData) {
+                this[item] = ParseEnvValue(
+                    ParsedConfigFileData[item as keyof object]
+                )
             }
         } else {
             for (const item in MozzConfig) {

--- a/source/utils/Parse.util.ts
+++ b/source/utils/Parse.util.ts
@@ -1,10 +1,19 @@
 export default function ParseEnvValue(input: string | number | boolean) {
     if (typeof input == 'string') {
-        const match = input.match(/\$(.*)\(['"](.*)['"]\)/)
+        const match = input.match(/\$(.*)\((.*)\)/)
+
+        if (Array(match?.[2])?.length <= 0) {
+            return input
+        }
 
         switch (match?.[1]) {
             case 'env':
-                return process.env[match?.[2]]
+                const args = match[2].split(',')
+
+                const envValue = process.env[args[0].slice(1).slice(0, -1)]
+                const defaultValue = args[1]
+
+                return normalizeValue(envValue || defaultValue)
 
             default:
                 return input
@@ -12,4 +21,14 @@ export default function ParseEnvValue(input: string | number | boolean) {
     }
 
     return input
+}
+
+export const normalizeValue = (input: string) => {
+    if (typeof input != 'string') return undefined
+
+    return input.startsWith("'") || input.startsWith('"')
+        ? String(input.slice(1).slice(0, -1)) // convert to a clean String
+        : isNaN(Number(input))
+        ? Boolean(input) // convert to a real Boolean
+        : Number(input) //          "         Number
 }

--- a/source/utils/Parse.util.ts
+++ b/source/utils/Parse.util.ts
@@ -1,0 +1,15 @@
+export default function ParseEnvValue(input: string | number | boolean) {
+    if (typeof input == 'string') {
+        const match = input.match(/\$(.*)\(['"](.*)['"]\)/)
+
+        switch (match?.[1]) {
+            case 'env':
+                return process.env[match?.[2]]
+
+            default:
+                return input
+        }
+    }
+
+    return input
+}


### PR DESCRIPTION
### Add support to functions in environment variables:
- `$env('VARIABLE', fallback?)`;

> Use example:
```json
{
    "environments": {
        "local": {
             "discord_bot_token": "$env('DISCORD_BOT_TOKEN')"
        }
    }
}
```

> Use example with fallback:
```json
{
    "environments": {
        "local": {
             "server_port": "8080"
        },
        "production": {
             "server_port": "$env('PORT', 8080)"
        },
    }
}
```

